### PR TITLE
Misc UX changes once more (#727)

### DIFF
--- a/zubhub_frontend/zubhub/src/assets/js/styles/components/staff_pick/staffPickStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/components/staff_pick/staffPickStyles.js
@@ -1,11 +1,11 @@
 const styles = theme => ({
   root: {
-    marginTop: '2em',
+    // marginTop: '2em',
     marginRight: '2em',
     width: '100%',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.5rem',
     marginLeft: '0.67em',
     marginRight: '0.67em',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/ambassadors/ambassadorsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/ambassadors/ambassadorsStyles.js
@@ -17,7 +17,7 @@ const styles = theme => ({
   },
   ambassadorsHeadingStyle: {
     fontSize: '2rem',
-    fontWeight: '900',
+    fontWeight: 'bold',
     color: 'black',
     margin: '1em 0',
   },

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_activity/createActivityStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_activity/createActivityStyles.js
@@ -5,7 +5,7 @@ export const styles = theme => ({
   },
   createActivityContainerTitle: {
     color: 'white',
-    fontWeight: 900,
+    fontWeight: 'bold',
   },
   CreateActivityFormContainer: {
     backgroundColor: 'white',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/create_project/createProjectStyles.js
@@ -23,7 +23,7 @@ const styles = theme => ({
     padding: '0 30px',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.7rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/edit_profile/editProfileStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/edit_profile/editProfileStyles.js
@@ -23,7 +23,7 @@ const styles = theme => ({
     padding: '0 30px',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.7rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/email_confirm/emailConfirmStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/email_confirm/emailConfirmStyles.js
@@ -23,7 +23,7 @@ const styles = theme => ({
     padding: '0 30px',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.7rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/group_members/groupMembersStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/group_members/groupMembersStyles.js
@@ -31,7 +31,7 @@ const styles = theme => ({
   },
   pageHeaderStyle: {
     marginTop: '1em',
-    fontWeight: 900,
+    fontWeight: 'bold',
     textAlign: 'center',
   },
   buttonGroupStyle: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/login/loginStyles.js
@@ -20,7 +20,7 @@ const styles = theme => ({
     padding: '0 30px',
   },
   ttitleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.7rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/password_reset/passwordResetStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/password_reset/passwordResetStyles.js
@@ -23,7 +23,7 @@ const styles = theme => ({
     padding: '0 30px',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.7rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/password_reset_confirm/passwordResetConfirmStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/password_reset_confirm/passwordResetConfirmStyles.js
@@ -23,7 +23,7 @@ const styles = theme => ({
     padding: '0 30px',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.7rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/profile/profileStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/profile/profileStyles.js
@@ -72,7 +72,7 @@ const styles = theme => ({
   userNameStyle: {
     wordBreak: 'break-all',
     lineHeight: '1.2',
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '2rem',
     [theme.breakpoints.down('740')]: {
       display: 'flex',
@@ -134,11 +134,11 @@ const styles = theme => ({
     borderRadius: 8,
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.5rem',
   },
   badgeTitleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.5rem',
     color: '#00B8C4',
   },

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/project_details/projectDetailsStyles.js
@@ -185,7 +185,7 @@ const styles = theme => ({
   },
   descriptionHeadingStyle: {
     marginTop: '1em',
-    fontWeight: 900,
+    fontWeight: '900',
     fontSize: '2.2rem',
   },
   descriptionBodyStyle: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/projects/projectsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/projects/projectsStyles.js
@@ -21,6 +21,7 @@ const styles = theme => ({
     paddingBottom: '2.85em',
     justifyContent: 'center',
     width: '100vw',
+    marginBottom: '2em'
   },
   imageLeft: {
     flexDirection: 'row', 
@@ -239,7 +240,7 @@ const styles = theme => ({
     marginBottom: '2em',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.5rem',
     marginTop: '2em',
     marginLeft: '0.67em',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/saved_projects/savedProjectsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/saved_projects/savedProjectsStyles.js
@@ -15,9 +15,7 @@ const styles = theme => ({
     width: '100%',
   },
   pageHeaderStyle: {
-    marginTop: '1em',
-    fontWeight: 900,
-    textAlign: 'center',
+    fontWeight: 'bold',
   },
   projectGridStyle: {
     marginBottom: '2em',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/search_results/searchResultsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/search_results/searchResultsStyles.js
@@ -19,7 +19,7 @@ const styles = theme => ({
 
   pageHeaderStyle: {
     marginTop: '1em',
-    fontWeight: 900,
+    fontWeight: 'bold',
     textAlign: 'center',
   },
   projectGridStyle: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/signup/signupStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/signup/signupStyles.js
@@ -24,7 +24,7 @@ const styles = theme => ({
     padding: '0 30px',
   },
   titleStyle: {
-    fontWeight: 900,
+    fontWeight: 'bold',
     fontSize: '1.7rem',
     [theme.breakpoints.up('1600')]: {
       fontSize: '2.5rem',

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/staff_pick_details/staffPickDetailsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/staff_pick_details/staffPickDetailsStyles.js
@@ -19,7 +19,7 @@ const styles = theme => ({
   },
   pageHeaderStyle: {
     marginTop: '1em',
-    fontWeight: 900,
+    fontWeight: 'bold',
     textAlign: 'center',
   },
   descriptionBodyStyle: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/user_followers/userFollowersStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/user_followers/userFollowersStyles.js
@@ -31,7 +31,7 @@ const styles = theme => ({
   },
   pageHeaderStyle: {
     marginTop: '1em',
-    fontWeight: 900,
+    fontWeight: 'bold',
     textAlign: 'center',
   },
   buttonGroupStyle: {

--- a/zubhub_frontend/zubhub/src/assets/js/styles/views/user_projects/userProjectsStyles.js
+++ b/zubhub_frontend/zubhub/src/assets/js/styles/views/user_projects/userProjectsStyles.js
@@ -19,7 +19,7 @@ const styles = theme => ({
 
   pageHeaderStyle: {
     marginTop: '1em',
-    fontWeight: 900,
+    fontWeight: 'bold',
     textAlign: 'center',
   },
   projectGridStyle: {

--- a/zubhub_frontend/zubhub/src/components/Navbar/Navbar.jsx
+++ b/zubhub_frontend/zubhub/src/components/Navbar/Navbar.jsx
@@ -352,7 +352,8 @@ function PageWrapper(props) {
                     <Typography className={clsx(common_classes.title2, classes.username)}>
                       {props.auth.username}
                     </Typography>
-                    <Typography className="">Student</Typography>
+                    {/* Todo: Change this subheading based on current role of user */}
+                    <Typography className="">Creator</Typography>
                   </Box>
                 )}
               </Hidden>

--- a/zubhub_frontend/zubhub/src/components/previewProject/previewProject.styles.js
+++ b/zubhub_frontend/zubhub/src/components/previewProject/previewProject.styles.js
@@ -218,7 +218,7 @@ const styles = theme => ({
     },
     descriptionHeadingStyle: {
         marginTop: '1em',
-        fontWeight: 900,
+        fontWeight: 'bold',
         fontSize: '2.2rem',
     },
     descriptionBodyStyle: {

--- a/zubhub_frontend/zubhub/src/components/staff_pick/StaffPick.jsx
+++ b/zubhub_frontend/zubhub/src/components/staff_pick/StaffPick.jsx
@@ -32,9 +32,9 @@ function StaffPick(props) {
         <Grid item xs={12}>
           <Typography
             gutterBottom
-            component="h2"
-            variant="h6"
-            color="textPrimary"
+            // component="h2"
+            // variant="h6"
+            // color="textPrimary"
             className={classes.titleStyle}
           >
             {staff_pick.title}

--- a/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
+++ b/zubhub_frontend/zubhub/src/views/PageWrapper.jsx
@@ -224,13 +224,13 @@ function PageWrapper(props) {
 
       <Container className={classes.childrenContainer} maxWidth="lg">
         {props.auth?.token ? <DashboardLayout>{loading ? <LoadingPage /> : props.children}</DashboardLayout> : null}
-        {!props.auth?.token && !['/', '/signup', '/login', '/projects/:id', '/ambassadors', '/creators/:username'].includes(props.match?.path) && (
+        {!props.auth?.token && !['/', '/signup', '/login', '/projects/:id', '/ambassadors', '/creators/:username', '/privacy_policy', '/terms_of_use', '/about', '/challenge'].includes(props.match?.path) && (
           <div style={{ minHeight: '80vh' }}>
             <NotFoundPage />
           </div>
         )}
       </Container>
-      {!props.auth?.token && ['/', '/signup', '/login', '/projects/:id', '/ambassadors', '/creators/:username'].includes(props.match?.path) && (
+      {!props.auth?.token && ['/', '/signup', '/login', '/projects/:id', '/ambassadors', '/creators/:username', '/privacy_policy', '/terms_of_use', '/about', '/challenge'].includes(props.match?.path) && (
           <div style={{minHeight: '90vh'}}>
             {props.children}
           </div>

--- a/zubhub_frontend/zubhub/src/views/ambassadors/Ambassadors.jsx
+++ b/zubhub_frontend/zubhub/src/views/ambassadors/Ambassadors.jsx
@@ -73,7 +73,7 @@ function Ambassadors(props) {
             </Typography>
 
 
-          <Grid container>
+          <Grid container spacing={3}>
             {ambassadors.projects.results.map(project => (
               <Grid
                 item

--- a/zubhub_frontend/zubhub/src/views/saved_projects/SavedProjects.jsx
+++ b/zubhub_frontend/zubhub/src/views/saved_projects/SavedProjects.jsx
@@ -62,11 +62,11 @@ function SavedProjects(props) {
     return (
       <Box className={classes.root}>
         <Container className={classes.mainContainerStyle}>
-          <Grid container>
+          <Grid container spacing={3}>
             <Grid item xs={12}>
               <Typography
                 className={classes.pageHeaderStyle}
-                variant="h3"
+                variant="h4"
                 gutterBottom
               >
                 {t('savedProjects.title')}


### PR DESCRIPTION
* Misc UX changes once more

* add class again

## Summary

Description of PR here...
Closes #85, Closes #22

## Changes

- Item 1
- Item 2
- Item 3

## Screenshots

(Insert image, only for frontend)

## Requests / Responses

**Request**
(Only for backend)
POST `/api/users` Returns a list of users

```
{
  "data": {
    "attributes": {
      "name": "The Dude",
      "email": "thedudeabides@wee.net",
      "password": "hellopassword"
    }
  },
  "type": "users"
}
```

**Response**
(Only for backend)
HTTP/1.1 200 OK

```
{
  "data": {
    "type": "users",
    "id": "4",
    "attributes": {
      "name": "The Dude",
      "email": "thedudeabides@wee.net",
      "last-logged-in": null,
      "created-at": "2016-10-20T17:45:08.190Z",
      "updated-at": "2016-10-20T17:45:08.190Z"
    },
    "links": {
      "self": "/users/4"
    }
  }
}
```
